### PR TITLE
Add termEnd to the Recalled event

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -78,7 +78,7 @@ contract Deploy is Script {
      *       never differs regardless of where its being compiled
      *    2. The provided salt, `SALT`
      */
-    implementation = new HatsElectionEligibility{ salt: SALT}(_version /* insert constructor args here */);
+    implementation = new HatsElectionEligibility{ salt: SALT }(_version /* insert constructor args here */ );
 
     vm.stopBroadcast();
 

--- a/src/HatsElectionEligibility.sol
+++ b/src/HatsElectionEligibility.sol
@@ -41,7 +41,7 @@ contract HatsElectionEligibility is HatsEligibilityModule {
 
   event NewTermStarted(uint128 termEnd);
 
-  event Recalled(address[] accounts);
+  event Recalled(uint128 termEnd, address[] accounts);
 
   /*//////////////////////////////////////////////////////////////
                             DATA MODELS
@@ -213,7 +213,7 @@ contract HatsElectionEligibility is HatsEligibilityModule {
       }
     }
 
-    emit Recalled(_recallees);
+    emit Recalled(_termEnd, _recallees);
   }
 
   /**

--- a/test/HatsElectionEligibility.t.sol
+++ b/test/HatsElectionEligibility.t.sol
@@ -49,7 +49,7 @@ contract ModuleTest is Deploy, Test {
   event ElectionOpened(uint128 nextTermEnd);
   event ElectionCompleted(uint128 termEnd, address[] winners);
   event NewTermStarted(uint128 termEnd);
-  event Recalled(address[] accounts);
+  event Recalled(uint128 termEnd, address[] accounts);
 
   error NotBallotBox();
   error NotAdmin();
@@ -435,7 +435,7 @@ contract Recalling is WithInstanceTest {
     recallees[0] = candidate1;
 
     vm.expectEmit();
-    emit Recalled(recallees);
+    emit Recalled(currentTermEnd, recallees);
 
     vm.prank(caller);
     instance.recall(currentTermEnd, recallees);
@@ -449,7 +449,7 @@ contract Recalling is WithInstanceTest {
     recallees[1] = candidate2;
 
     vm.expectEmit();
-    emit Recalled(recallees);
+    emit Recalled(currentTermEnd, recallees);
 
     vm.prank(caller);
     instance.recall(currentTermEnd, recallees);


### PR DESCRIPTION
For indexing support, we need a way to know for which term the recall operation was performed